### PR TITLE
Fix bug where team name is being compared with team slug

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9008,23 +9008,22 @@ async function main() {
 
         if (review.state === "APPROVED") {
             for (const team of userTeams) {
-                const teamName = team.name.toLowerCase().replace(/ /g, "-");
-                if (requiredCodeownerEntities.hasOwnProperty(teamName)) {
+                if (requiredCodeownerEntities.hasOwnProperty(team.slug)) {
                     if (
                         requireAllApprovalsLatestCommit === "true" &&
                         review.commit_id !== pr.head.sha
                     ) {
                         console.info(
-                            `  ${reviewerLogin} ${review.state}: at commit: ${review.commit_id} for: ${team.name} (not the latest commit, ignoring)`
+                            `  ${reviewerLogin} ${review.state}: at commit: ${review.commit_id} for: ${team.slug} (not the latest commit, ignoring)`
                         );
                         continue;
                     }
-                    requiredCodeownerEntities[teamName] = true;
+                    requiredCodeownerEntities[team.slug] = true;
                     if (!approvedCodeowners.includes(review.user.login)) {
                         approvedCodeowners.push(review.user.login);
                     }
                     console.info(
-                        `  ${reviewerLogin} ${review.state}: at commit: ${review.commit_id} for: ${team.name}`
+                        `  ${reviewerLogin} ${review.state}: at commit: ${review.commit_id} for: ${team.slug}`
                     );
                 }
             }
@@ -9037,10 +9036,9 @@ async function main() {
             }
         } else if (review.state === "CHANGES_REQUESTED") {
             for (const team of userTeams) {
-                const teamName = team.name.toLowerCase();
-                if (requiredCodeownerEntities.hasOwnProperty(teamName)) {
-                    requiredCodeownerEntities[teamName] = false;
-                    console.info(`  ${reviewerLogin} ${review.state}: for: ${team.name}`);
+                if (requiredCodeownerEntities.hasOwnProperty(team.slug)) {
+                    requiredCodeownerEntities[team.slug] = false;
+                    console.info(`  ${reviewerLogin} ${review.state}: for: ${team.slug}`);
                 }
             }
             if (requiredCodeownerEntities.hasOwnProperty(reviewerLogin)) {

--- a/src/index.js
+++ b/src/index.js
@@ -200,23 +200,22 @@ async function main() {
 
         if (review.state === "APPROVED") {
             for (const team of userTeams) {
-                const teamName = team.name.toLowerCase().replace(/ /g, "-");
-                if (requiredCodeownerEntities.hasOwnProperty(teamName)) {
+                if (requiredCodeownerEntities.hasOwnProperty(team.slug)) {
                     if (
                         requireAllApprovalsLatestCommit === "true" &&
                         review.commit_id !== pr.head.sha
                     ) {
                         console.info(
-                            `  ${reviewerLogin} ${review.state}: at commit: ${review.commit_id} for: ${team.name} (not the latest commit, ignoring)`
+                            `  ${reviewerLogin} ${review.state}: at commit: ${review.commit_id} for: ${team.slug} (not the latest commit, ignoring)`
                         );
                         continue;
                     }
-                    requiredCodeownerEntities[teamName] = true;
+                    requiredCodeownerEntities[team.slug] = true;
                     if (!approvedCodeowners.includes(review.user.login)) {
                         approvedCodeowners.push(review.user.login);
                     }
                     console.info(
-                        `  ${reviewerLogin} ${review.state}: at commit: ${review.commit_id} for: ${team.name}`
+                        `  ${reviewerLogin} ${review.state}: at commit: ${review.commit_id} for: ${team.slug}`
                     );
                 }
             }
@@ -229,10 +228,9 @@ async function main() {
             }
         } else if (review.state === "CHANGES_REQUESTED") {
             for (const team of userTeams) {
-                const teamName = team.name.toLowerCase();
-                if (requiredCodeownerEntities.hasOwnProperty(teamName)) {
-                    requiredCodeownerEntities[teamName] = false;
-                    console.info(`  ${reviewerLogin} ${review.state}: for: ${team.name}`);
+                if (requiredCodeownerEntities.hasOwnProperty(team.slug)) {
+                    requiredCodeownerEntities[team.slug] = false;
+                    console.info(`  ${reviewerLogin} ${review.state}: for: ${team.slug}`);
                 }
             }
             if (requiredCodeownerEntities.hasOwnProperty(reviewerLogin)) {


### PR DESCRIPTION
The code was erroneously comparing team name with the team slug which resulted in an otherwise approved PR not passing the check.  The CODEOWNERS file must take team slugs instead of team names which is where the issue arises from. 
 Consider the following example.

**Team**
Name: "com.example.some name"
Slug: "com-example-some-name"

**CODEOWNERS File**
`* @owner-name/com-example-some-name`

The code was taking the team name of "com.example.some name" and replacing only spaces with "-" which resulted in the code trying to compare "com.example.some-name" with "com-example-some-name" which then resulted in the check failing.