### PR TITLE
fix: allign patterns check logic with Github ones

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,13 +46,12 @@ async function getRequiredCodeowners(changedFiles, repo, pr, octokit) {
 
         let [pattern, ...owners] = line.trim().split(/\s+/);
 
-        if (!pattern.startsWith('/')) {
-            pattern = `**/${pattern}`;
-        }
-
         if (pattern === '*') {
             updateCodeowners(owners);
         } else {
+            if (!pattern.startsWith('/')) {
+                pattern = `**/${pattern}`;
+            }
             for (let changedFile of changedFiles) {
                 changedFile = `/${changedFile}`;
                 if (minimatch(changedFile, pattern)) {
@@ -175,7 +174,7 @@ async function main() {
     );
 
     const requiredCodeownerEntities = await getRequiredCodeowners(changedFiles, repo.data, pr, octokit);
-    console.info(`Required codeowners: ${JSON.stringify(requiredCodeownerEntities)}`);
+    console.info(`Required codeowners: ${Object.keys(requiredCodeownerEntities).join(', ')}`);
 
     const orgTeams = [];
 

--- a/src/index.js
+++ b/src/index.js
@@ -44,12 +44,17 @@ async function getRequiredCodeowners(changedFiles, repo, pr, octokit) {
             continue;
         }
 
-        const [pattern, ...owners] = line.trim().split(/\s+/);
+        let [pattern, ...owners] = line.trim().split(/\s+/);
+
+        if (!pattern.startsWith('/')) {
+            pattern = `**/${pattern}`;
+        }
 
         if (pattern === '*') {
             updateCodeowners(owners);
         } else {
-            for (const changedFile of changedFiles) {
+            for (let changedFile of changedFiles) {
+                changedFile = `/${changedFile}`;
                 if (minimatch(changedFile, pattern)) {
                     updateCodeowners(owners);
                 }


### PR DESCRIPTION
The current verification of patterns does not follow the same logic as Github's when they do not start with `/`, which causes Codeowners to mismatch in these cases.

From [Github documentation](https://docs.github.com/es/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file):

```
# In this example, @octocat owns any file in an apps directory
# anywhere in your repository.
apps/ @octocat

```
**Changes made:**

- Concatenate `**/` at the beginning of patterns in case they don't start with `/` to follow the same logic.
- A `/` is concatenated at the beginning of each `changedFile` string to make the minimatch function work well on those patterns with a `/` at the beginning.
- Modify required approvals logging from `"Required codeowners: {"$CODEOWNER":false}"` to `"Required codeowners: $CODEOWNER"` as it can lead to confusion 