### PR TITLE
Add getContent headers for large file support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -108,8 +108,12 @@ async function getContent(octokit, repo, path, ref) {
             repo: repo.name,
             path,
             ref,
+            headers: {
+                // Raw media type necessary for files over 1MB
+                accept: "application/vnd.github.v3.raw",
+            }
         });
-        return Buffer.from(data.content, "base64").toString();
+        return data;
     } catch (error) {
         if (error.status === 404) {
             return null;


### PR DESCRIPTION
From https://octokit.github.io/rest.js/v21/#repos-get-content

> If the requested file's size is:
> - 1 MB or smaller: All features of this endpoint are supported.
> - Between 1-100 MB: Only the raw or object custom media types are supported. Both will work as normal, except that when using the object media type, the content field will be an empty string and the encoding field will be "none". To get the contents of these larger files, use the raw media type.
> - Greater than 100 MB: This endpoint is not supported.

Since there's only this one call to `getContent` and it requires the raw file text, I don't think there are any other changes needed

(adding so I can use this for a project with a larger codeowners file)